### PR TITLE
Fixed travis-ci links so that builds display correctly in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ make test
 
 Then:
 
-* If you haven't already, link your GitHub account to [Travis CI](https://travis-ci.org/signup).
-* The repo might start building on Travis automatically, but if it doesn't [add it manually](https://travis-ci.org/account/repositories).
+* If you haven't already, link your GitHub account to [Travis CI](https://travis-ci.com/signup).
+* The repo might start building on Travis automatically, but if it doesn't [add it manually](https://travis-ci.com/account/repositories).
 * To enable automatic GitHub pages deployment, store a secret GithHub access token to the Travis-CI environment variable `GH_TOKEN`.
   1. [Generate a new GitHub personal access token.](https://github.com/settings/tokens/new)
     * [x] Select the `repo` (`Full control of private repositories`) scope.

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -5,7 +5,7 @@
 
 {% if is_open_source %}
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
-        :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+        :target: https://travis-ci.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest
         :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
Changed all travis-ci.org links to travis-ci.com to fix a bug where the build status was stuck on "unknown"