### PR TITLE
Update Empirical include paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test clean
 
-COOKIECUTTER_EMP_DIR ?= third-party/Empirical/source
+COOKIECUTTER_EMP_DIR ?= third-party/Empirical/include
 
 ../cut-cookie:
 	mkdir -p ../cut-cookie

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
   "project_short_description": "An instantiation of the Cookiecutter Empirical Project.",
   "version": "0.1.0",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
-  "emp_dir": "third-party/Empirical/source",
+  "emp_dir": "third-party/Empirical/include",
   "deployment_branch": "master",
   "landing_page": ["Yes", "No"],
   "docker_username": "{{ cookiecutter.github_username }}"

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -12,7 +12,7 @@ CFLAGS_nat_debug := -g $(CFLAGS_all)
 
 # Emscripten compiler information
 CXX_web := emcc
-OFLAGS_web_all := -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'cwrap']" -s TOTAL_MEMORY=67108864 --js-library $(EMP_DIR)/web/library_emp.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 #--embed-file configs
+OFLAGS_web_all := -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'cwrap']" -s TOTAL_MEMORY=67108864 --js-library $(EMP_DIR)/emp/web/library_emp.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 #--embed-file configs
 OFLAGS_web := -Oz -DNDEBUG
 OFLAGS_web_debug := -g4 -Oz -Wno-dollar-in-identifier-extension
 

--- a/{{cookiecutter.project_slug}}/source/native.cpp
+++ b/{{cookiecutter.project_slug}}/source/native.cpp
@@ -4,8 +4,8 @@
 
 #include <iostream>
 
-#include "base/vector.h"
-#include "config/command_line.h"
+#include "emp/base/vector.hpp"
+#include "emp/config/command_line.hpp"
 
 #include "{{cookiecutter.project_slug}}/example.hpp"
 

--- a/{{cookiecutter.project_slug}}/source/web.cpp
+++ b/{{cookiecutter.project_slug}}/source/web.cpp
@@ -4,7 +4,7 @@
 
 #include <iostream>
 
-#include "web/web.h"
+#include "emp/web/web.hpp"
 
 #include "{{cookiecutter.project_slug}}/example.hpp"
 


### PR DESCRIPTION
Update include paths in cookie cutter to match recent changes to Empirical's directory structure.